### PR TITLE
fix(flate): mise-action but exclude excess mise tools

### DIFF
--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -45,9 +45,10 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           cache: false
-          install: false
-      - name: Install Flate
-        run: mise use -g github:home-operations/flate@0.1.27
+          tool_versions: |
+            github:home-operations/flate latest
+        env:
+          MISE_ENABLE_TOOLS: "flate"
       - name: Flate Test
         run: flate test all --path ./kubernetes --allow-missing-secrets
   flate-diff:
@@ -91,9 +92,10 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           cache: false
-          install: false
-      - name: Install Flate
-        run: mise use -g github:home-operations/flate@0.1.27
+          tool_versions: |
+            github:home-operations/flate latest
+        env:
+          MISE_ENABLE_TOOLS: "flate"
       - name: Run flate diff
         id: diff
         env:

--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -45,10 +45,9 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           cache: false
+          install_args: "github:home-operations/flate"
           tool_versions: |
             github:home-operations/flate latest
-        env:
-          MISE_ENABLE_TOOLS: "flate"
       - name: Flate Test
         run: flate test all --path ./kubernetes --allow-missing-secrets
   flate-diff:
@@ -92,10 +91,9 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           cache: false
+          install_args: "github:home-operations/flate"
           tool_versions: |
             github:home-operations/flate latest
-        env:
-          MISE_ENABLE_TOOLS: "flate"
       - name: Run flate diff
         id: diff
         env:

--- a/kubernetes/apps/default/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: echo2
+  name: echo
 spec:
   chartRef:
     kind: OCIRepository

--- a/kubernetes/apps/default/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/default/echo/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: echo
+  name: echo2
 spec:
   chartRef:
     kind: OCIRepository
@@ -40,7 +40,7 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 10m
@@ -62,7 +62,8 @@ spec:
           - port: http
     route:
       app:
-        hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
           - name: envoy-external
             namespace: network


### PR DESCRIPTION
# Manual Pull Request

## 🚀 Summary
Edit the testing workflow to use the mise action to install Flate with install_args to make sure it does not try to install the entire mise.toml from the repository root.

## 📦 Affected Areas

- [ ] HelmRelease
- [ ] Kustomization
- [ ] Secrets (External Secrets, SOPS)
- [ ] Cluster Bootstrap
- [ ] Ingress
- [ ] Monitoring
- [ ] VolSync / Backups
- [x] CI
- [ ] Other: <!-- Specify -->

---

## ✅ Checklist

- [ ] Secrets encrypted with SOPS or specified as External Secrets
- [ ] No plaintext secrets committed
- [ ] Base domain, hostnames, and URLs are templated correctly
- [ ] Certifcate issuer set correctly
- [ ] Required OCI repositories set with correct version and image
- [ ] Integrations set correctly
- [ ] Chart versions are correct vs upstream
- [ ] Gateway API routes and policies set correctly
- [ ] Volsync setup correctly
- [ ] Kustomizations reference correct chart and path
- [x] CI workflows (if applicable) run successfully
- [ ] Namespace is correct and consistent
- [ ] Privileged setup where necessary

---

## 🧠 Notes for Myself

<!-- Leave any reminders, notes, or follow-ups for future you here. -->
